### PR TITLE
Add thumbnails to main table

### DIFF
--- a/SC4PropTextureCatalog4/index.html
+++ b/SC4PropTextureCatalog4/index.html
@@ -23,7 +23,7 @@
             <input type="Submit" value="Search" />
         </form>
 
-        <fieldset class="grid" style="width:200px; height:50px">
+        <fieldset class="grid">
             <details class="dropdown" id="Categories">
                 <summary>TGI Category</summary>
                 <ul>
@@ -35,19 +35,10 @@
                 </ul>
             </details>
 
-            <!--<div>
-                <input id="ThumbnailToggle" type="checkbox" role="switch" />
-                <label for="ThumbnailToggle">Show Thumbnails</label>
-            </div>
-
-            <details class="dropdown" id="ThumbnailSize">
-                <summary>Thumbnail Size</summary>
-                <ul>
-                    <li><label><input type="radio" name="tsize" value="32px" />32 px</label></li>
-                    <li><label><input type="radio" name="tsize" value="64px" />64 px</label></li>
-                    <li><label><input type="radio" name="tsize" value="96px" />96 px</label></li>
-                </ul>
-            </details>-->
+            <label>
+                Thumbnail Size
+                <input id="ThumbnailSize" type="range" min="0" max="128" step="16" value="80" />
+            </label>
         </fieldset>
 
 
@@ -63,7 +54,7 @@
                     <th>TGI</th>
                     <th>Category</th>
                     <th>Author</th>
-                    <!--<th>Thumbnail</th>-->
+                    <th class="thumbnail-col">Thumbnail</th>
                     <th>Exemplar Name</th>
                 </tr>
             </thead>

--- a/SC4PropTextureCatalog4/js/site-search.js
+++ b/SC4PropTextureCatalog4/js/site-search.js
@@ -22,10 +22,22 @@ document.getElementById('ThumbnailSize').addEventListener('input', () => {
 	});
 });
 
-
-document.getElementById('SearchForm').addEventListener('submit', () => {
+document.getElementById('SearchForm').addEventListener('submit', (event) => {
 	event.preventDefault();
-	SendQuery(document.getElementById('SearchBox').value);
+	const searchText = document.getElementById('SearchBox').value;
+	let query_results = [];
+	fetch(apiUrl + '/api/search?term=' + encodeURIComponent(searchText))
+		.then(response => {
+			if (!response.ok) {
+				throw new Error(`HTTP error! Status: ${response.status}`);
+			}
+			return response.json();
+		})
+		.then(data => {
+			query_results = data;
+			QueryReturn(searchText, query_results);
+		});
+	
 });
 
 const categories = document.getElementById('Categories').getElementsByTagName('input');
@@ -39,23 +51,11 @@ Array.from(categories).forEach(chk => {
 });
 
 
-function SendQuery(searchText) {
-	let query_results = [];
-	fetch(apiUrl + '/api/search?term=' + encodeURIComponent(searchText))
-		.then(response => {
-			if (!response.ok) {
-				throw new Error(`HTTP error! Status: ${response.status}`);
-			}
-			return response.json();
-		})
-		.then(data => {
-			query_results = data;
-			QueryReturn(searchText, query_results);
-		});
-}
-
-
-
+/**
+ * Update the main table with the query results.
+ * @param {string} search_text Query search text
+ * @param {Array} query_results Results of the query
+ */
 function QueryReturn(search_text, query_results) {
 	document.getElementById('QueryResultSummary').style.display = 'block';
 	document.getElementById('QueryResultTable').style.display = 'block';

--- a/SC4PropTextureCatalog4/js/site-search.js
+++ b/SC4PropTextureCatalog4/js/site-search.js
@@ -57,6 +57,7 @@ function QueryReturn(search_text, query_results) {
 	document.getElementById('QueryFilterCount').textContent = query_results.length;
 
 	const body = document.getElementById('QueryResultBody');
+	body.replaceChildren();
 	query_results.forEach(item => {
 		const tr = document.createElement("tr");
 

--- a/SC4PropTextureCatalog4/js/site-search.js
+++ b/SC4PropTextureCatalog4/js/site-search.js
@@ -1,19 +1,26 @@
 // Setup on page load
 document.getElementById('QueryResultSummary').style.display = 'none';
 document.getElementById('QueryResultTable').style.display = 'none';
-ToggleThumbnailControlVisibility();
 
-function ToggleThumbnailControlVisibility() {
-	const bgGroup = document.getElementById("BackgroundGroup");
+
+document.getElementById('ThumbnailSize').addEventListener('input', () => {
 	const sizeElem = document.getElementById('ThumbnailSize');
-	// if (document.getElementById("ThumbnailToggle").checked) {
-	// 	bgGroup.style.display = "block";
-	// 	sizeElem.style.display = "block";
-	// } else {
-	// 	bgGroup.style.display = "none";
-	// 	sizeElem.style.display = "none";
-	// }
-}
+	const thumbCol = document.getElementById('QueryResultTable').getElementsByClassName('thumbnail-col');
+	if (sizeElem.value == "0") {
+		Array.from(thumbCol).forEach(cell => cell.style.display = 'none');
+	} else {
+		Array.from(thumbCol).forEach(cell => cell.style.display = '');
+	}
+	const images = document.getElementById('QueryResultBody').getElementsByTagName('img');
+	Array.from(images).forEach(img => {
+		if (sizeElem.value == "0") {
+			img.style.display = 'none';
+		} else {
+			img.style.display = '';
+			img.style.height = sizeElem.value + 'px';
+		}
+	});
+});
 
 
 document.getElementById('SearchForm').addEventListener('submit', () => {
@@ -79,11 +86,13 @@ function QueryReturn(search_text, query_results) {
 		const author = document.createElement("td");
 		author.textContent = item.Author;
 
-		//const thumb = document.createElement('td');
-		//const img = document.createElement('img');
-		//img.src = "img/7AB50E44-0986135E-1DA4A000.png";
-		//img.style.height = document.getElementById('ThumbnailSize').value;
-		//thumb.appendChild(img);
+		const thumb = document.createElement('td');
+		thumb.classList.add('thumbnail-col');
+		const img = document.createElement('img');
+		img.src = `https://thumbs.sc4proptexturecatalog.net/textures/${item.TGI.replaceAll(", ", "-").replaceAll("0x", "").toUpperCase()}.png`;
+		img.style.height = document.getElementById('ThumbnailSize').value + 'px';
+		img.style.border = "1px solid var(--pico-form-element-border-color)";
+		thumb.appendChild(img);
 
 		const name = document.createElement("td");
 		name.textContent = item.ExemplarName ?? "null";
@@ -91,8 +100,7 @@ function QueryReturn(search_text, query_results) {
 			name.style.fontStyle = "oblique";
 		}
 		
-
-		tr.append(package, file, tgi, category, author, name);
+		tr.append(package, file, tgi, category, author, thumb, name);
 		body.appendChild(tr);
 	});
 


### PR DESCRIPTION
Adds thumbnails to the main query table. They can be hidden by setting the size slider to zero. Also fix the issue where previous query results were not cleared with a new query resulting in items continually stacking in the table.